### PR TITLE
Generate the docker compose file from templates during build (if needed)

### DIFF
--- a/pydc_control/commands.py
+++ b/pydc_control/commands.py
@@ -154,9 +154,12 @@ def run_dc_build(args: argparse.Namespace):
     if args.dev_project_names and not args.all_projects:
         dev_projects = _get_dev_projects(args)
         for project in dev_projects:
-            docker_compose_args.extend(
-                docker_utils.read_services_from_dc(os.path.join(project.path, config.DOCKER_COMPOSE_FILE))
-            )
+            # Sometimes the docker compose file might be missing during a build. If so, just generate it right now.
+            # This should only run once for all dev projects
+            dc_file_path = os.path.join(project.path, config.DOCKER_COMPOSE_FILE)
+            if not os.path.exists(dc_file_path):
+                docker_compose_utils.init_docker_compose(args, dev_projects, no_network=True)
+            docker_compose_args.extend(docker_utils.read_services_from_dc(dc_file_path))
     return _run_docker_compose_internal(args, docker_compose_args)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There were issues identified when building projects with a `docker-compose-template.yml` file if the generated version was deleted before a `build` command was issued. This prevents this by checking for the condition and generating the `docker-compose.yml` file.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.