### PR TITLE
Add support for marking services are enabled by other services

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,14 @@ services:
   {%- endif %}
 ```
 
+#### Using enable flags from other services
+
+Sometimes it is desired to use a single enable flag to enable multiple services across projects.
+This may be done by setting the `enable` or `disable` flags to the name of the service to use
+for enabling/disabling. This requires that the other service also has the same flag set to `true`.
+Multiple levels of enable/disable redirection are not possible (e.g. s1 is enabled with  s2 which
+is enabled with s3).
+
 ### Create your own control script commands
 
 It is easy to create additional commands using pydc_control.

--- a/pydc_control/cli.py
+++ b/pydc_control/cli.py
@@ -24,7 +24,7 @@ def _get_print_help_func(parser):
     return print_help
 
 
-def _parse_args(configure_parsers: Callable, args: Optional[Sequence[str]]) -> argparse.Namespace:
+def _parse_args(configure_parsers: Optional[Callable], args: Optional[Sequence[str]]) -> argparse.Namespace:
     # pylint: disable=too-many-locals
 
     # Get all projects defined in the configuration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I want to be able to have an enable flag to enable multiple services. This adds the support for doing so and extends it to the disable flag as well.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

See description

## How Has This Been Tested?

I added some unit testing for it to ensure it is working properly. This uses the full CLI parsing along with a real project configuration to ensure that it all links up correctly in the end.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.