### PR TITLE
No longer generate docker compose version 3 since it is deprecated

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ jobs:
         - 3.7
         - 3.8
         - 3.9
+        - '3.10'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -31,7 +32,7 @@ jobs:
     - name: Test with pytest
       run: pytest --junitxml=test-reports/test-results.xml
     - name: Publish test results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         files: test-reports/test-results.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - 3.6
         - 3.7
         - 3.8
         - 3.9
@@ -33,8 +32,7 @@ jobs:
       run: pytest --junitxml=test-reports/test-results.xml
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      # exclude this step for 3.6, since it fails due to a breaking change to EnricoMi/publish-unit-test-result-action
-      if: always() && matrix.python-version != '3.6'
+      if: always()
       with:
         files: test-reports/test-results.xml
         check_name: "Test Results ${{ matrix.python-version }}"

--- a/pydc_control/docker_compose_utils.py
+++ b/pydc_control/docker_compose_utils.py
@@ -171,7 +171,6 @@ def _generate_docker_compose(args: argparse.Namespace, dev_projects: List[Projec
 
     # Write out base docker compose
     docker_compose_data = {
-        'version': '3',
         'networks': {
             config.get_dc_network(): {
                 'external': True,


### PR DESCRIPTION
The docker compose version field is now deprecated and the syntax has been merged between version 2 and 3.